### PR TITLE
[WIP] Curl_quic_idle

### DIFF
--- a/lib/quic.h
+++ b/lib/quic.h
@@ -54,6 +54,7 @@ void Curl_quic_done(struct Curl_easy *data, bool premature);
 bool Curl_quic_data_pending(const struct Curl_easy *data);
 void Curl_quic_disconnect(struct Curl_easy *data,
                           struct connectdata *conn, int tempindex);
+CURLcode Curl_quic_idle(struct Curl_easy *data);
 
 #else /* ENABLE_QUIC */
 #define Curl_quic_done_sending(x)

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1222,6 +1222,13 @@ CURLcode Curl_readwrite(struct connectdata *conn,
         infof(data, "Done waiting for 100-continue");
       }
     }
+
+#ifdef ENABLE_QUIC
+    if(conn->transport == TRNSPRT_QUIC)
+      result = Curl_quic_idle(data);
+    if(result)
+      return result;
+#endif
   }
 
   if(Curl_pgrsUpdate(data))

--- a/lib/vquic/msh3.c
+++ b/lib/vquic/msh3.c
@@ -495,4 +495,11 @@ bool Curl_quic_data_pending(const struct Curl_easy *data)
   return stream->recv_header_len || stream->recv_data_len;
 }
 
+CURLcode Curl_quic_idle(struct Curl_easy *data)
+{
+  (void)data;
+  H3BUGF(infof(data, "Curl_quic_idle"));
+  return CURLE_OK;
+}
+
 #endif /* USE_MSH3 */

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -1883,4 +1883,26 @@ bool Curl_quic_data_pending(const struct Curl_easy *data)
   return Curl_dyn_len(&stream->overflow) > 0;
 }
 
+/*
+ * Called from transfer.c:Curl_readwrite when neither HTTP level read
+ * or write is performed. It is a good place to handle timer expiry
+ * for QUIC transport.
+ */
+CURLcode Curl_quic_idle(struct Curl_easy *data)
+{
+  struct connectdata *conn = data->conn;
+  curl_socket_t sockfd = conn->sock[FIRSTSOCKET];
+  struct quicsocket *qs = conn->quic;
+
+  if(ngtcp2_conn_get_expiry(qs->qconn) > timestamp()) {
+    return CURLE_OK;
+  }
+
+  if(ng_flush_egress(data, sockfd, qs)) {
+    return CURLE_SEND_ERROR;
+  }
+
+  return CURLE_OK;
+}
+
 #endif

--- a/lib/vquic/quiche.c
+++ b/lib/vquic/quiche.c
@@ -856,4 +856,10 @@ bool Curl_quic_data_pending(const struct Curl_easy *data)
   return FALSE;
 }
 
+CURLcode Curl_quic_idle(struct Curl_easy *data)
+{
+  (void)data;
+  return CURLE_OK;
+}
+
 #endif


### PR DESCRIPTION
Curl_quic_idle to be called when no HTTP level read or write is
performed.  It is a good place to handle timer expiry for QUIC
transport (.e.g, retransmission).